### PR TITLE
Update requirements.txt for pytorch-lightning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pytorch-lightning>=1.1.*
+pytorch-lightning==1.3.8
 torch>=1.8.1
 torchvision>=0.9.0
 imageio~=2.9.0


### PR DESCRIPTION
Because `pytorch_lightning.metrics` is deprecated from v1.3 and will be removed in v1.5. (https://pytorch-lightning.readthedocs.io/en/stable/extensions/metrics.html)
To be able to load `fastface` the version of `pytorch_lightning` is fixed to `1.3.8`.